### PR TITLE
fix bugs

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@
 CLI for Managing Front-matter in Markdown Files.
 """
 
+import frontmatter
 import argparse
 import logging
 import os
@@ -12,8 +13,6 @@ import pathlib
 import shutil
 import sys
 import tempfile
-
-import frontmatter
 
 def main(obsidian_vault_root, required_tags=None, dry_run=False):
     """
@@ -44,10 +43,14 @@ def main(obsidian_vault_root, required_tags=None, dry_run=False):
                     continue
             else:
                 md['tags'] = []
-            md['tags'] = sorted(set(md['tags'] + required_tags))
+            if required_tags:
+                md['tags'] = sorted(set(md['tags'] + required_tags))
+            else:
+                md['tags'] = sorted(set(md['tags']))
             # Write modified md object (front-matter + content) to temp file
             root = tmp_vault_root if dry_run else obsidian_vault_root
-            filename_to_write = os.path.join(root, filename)
+            # filename_to_write = os.path.join(root, filename)
+            filename_to_write = os.path.join(root, rootdirpath, filename)
             with open(filename_to_write, 'wb') as f:
                 frontmatter.dump(md, f)
             logger.debug(f"\t{filename}: {md['tags']}")

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ def main(obsidian_vault_root, required_tags=None, dry_run=False):
         logger.debug(f"walking root dir {rootdirpath}. Pruned dirs: {dirnames}")
         for filename in [f for f in filenames if os.path.splitext(f)[1] == '.md']:
             md = frontmatter.load(os.path.join(rootdirpath, filename))
-            if 'tags' in md.keys():
+            if '- Tags' in md.keys():
                 if all([t in md['tags'] for t in required_tags]):
                     logger.debug(f"\t{filename}: already has required_tags.")
                     continue
@@ -49,7 +49,6 @@ def main(obsidian_vault_root, required_tags=None, dry_run=False):
                 md['tags'] = sorted(set(md['tags']))
             # Write modified md object (front-matter + content) to temp file
             root = tmp_vault_root if dry_run else obsidian_vault_root
-            # filename_to_write = os.path.join(root, filename)
             filename_to_write = os.path.join(root, rootdirpath, filename)
             with open(filename_to_write, 'wb') as f:
                 frontmatter.dump(md, f)


### PR DESCRIPTION
- error if files has tag already exist.  fix bug - script got error with files which contain that tag already
- upgrade for files which use sub-folders. Put them on their origin paths. Before that files replaced to the root.